### PR TITLE
Allow regions to be defined without parameters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -154,7 +154,7 @@ We will define a Region to isolate information for a single president.  This wil
 
 The key piece in defining the region is the filter, which reduces the scope Watir is looking at by starting with +Parfait::browser+, applying the filter and then calling +Parfait::filter_browser+ to store the reduced scope. 
 
-The add_filter method will take a single parameter - if more are necessary, then a subfilter should be used instead.
+To filter based on an input, the add_filter method should take a single parameter - if more are necessary, then a subfilter should be used instead.  To filter without an input, the add_filter method can be written with no parameters.
   
   # Define a filter so that this region will allow focus on a single entry
   president_region.add_filter { |president_name|
@@ -265,6 +265,8 @@ We can submit our change using the "Set My Party" button:
 Using the Region we defined, we can also easily manipulate controls within the table.  To change the nickname for John Adams, we can just target his table entry like this:
 
   app.page("Sample Page").region("President" => "John Adams").control("Nickname").update "Sammy's Bro"
+
+Note that if the filter for this region were written without need for a parameter, the +region()+ call would take only the name of the Region instead of a Hash.
 
 Similarly, we can verify his nickname:
 

--- a/lib/parfait/page.rb
+++ b/lib/parfait/page.rb
@@ -122,21 +122,33 @@ module Parfait
     #
     # *Options*
     #
-    # +name+:: specifies the name or alias of the region
+    # +opts+:: is either a hash with a key specifying the name of the region and a value
+    # specifying the filter search value OR is a value specifying the name of the region
     #
     # *Example*
     #
     #   myregion.region("User List" => username)
+    #   myregion.region("Chat Box")
     #
     def region(opts = {})
-      region = @regions[opts.first[0]] 
+      if opts.is_a?(Hash)
+        region_name = opts.first[0]
+      else
+        region_name = opts
+      end
+      region = @regions[region_name]
+
       if region
 
         # Confirm that we are on the expected page
-        verify_presence "Cannot navigate to region \"#{opts.first[0]}\" because page presence check failed"
+        verify_presence "Cannot navigate to region \"#{region_name}\" because page presence check failed"
 
         # Apply the filter method
-        region.filter(opts.first[1])
+        if opts.is_a?(Hash)
+          region.filter(opts.first[1])
+        else
+          region.filter(opts)
+        end
 
         return region
       else

--- a/parfait.gemspec
+++ b/parfait.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'parfait'
-  s.version     = '0.12.2'
-  s.date        = '2017-01-07'
+  s.version     = '0.12.3'
+  s.date        = '2017-08-25'
   s.summary     = 'Parfait'
   s.description = 'Parfait uses layers to simplify the creation and maintenance of your web browser test automation.'
   s.add_development_dependency "minitest", [">= 0"]

--- a/test/test_region.rb
+++ b/test/test_region.rb
@@ -113,4 +113,16 @@ class RegionTest < Minitest::Test
     assert_raises(RuntimeError) { r.add_region(c) }
   end
 
+  def test_filter_flexibility
+    p = Parfait::Page.new(:name => "page")
+    r1 = Parfait::Region.new(:name => "region1")
+    r1.add_filter { |a| a }
+    assert r1.add_to_page(p).is_a?(Parfait::Region)
+    assert p.region("region1") == r1
+    r2 = Parfait::Region.new(:name => "region2")
+    r2.add_filter { true }
+    assert r2.add_to_page(p).is_a?(Parfait::Region)
+    assert p.region("region2") == r2
+  end
+
 end


### PR DESCRIPTION
Allow regions to be called with a filter parameter (e.g. `mypage.region("Users" => "Bob")`) or without a parameter (e.g. `mypage.region("Chat Box")`).