### PR TITLE
Allowing for regions within regions to also utilize parameterless filters

### DIFF
--- a/lib/parfait/region.rb
+++ b/lib/parfait/region.rb
@@ -259,21 +259,33 @@ module Parfait
     #
     # *Options*
     #
-    # +name+:: specifies the name or alias of the region
+    # +opts+:: is either a hash with a key specifying the name of the region and a value
+    # specifying the filter search value OR is a value specifying the name of the region
     #
     # *Example*
     #
     #   myregion.region("User List" => username)
+    #   myregion.region("Chat Box")
     #
     def region(opts = {})
-      region = @regions[opts.first[0]] 
+      if opts.is_a?(Hash)
+        region_name = opts.first[0]
+      else
+        region_name = opts
+      end
+      region = @regions[region_name]
+
       if region
 
-        # Confirm that we are in the expected region
-        verify_presence "Cannot navigate to region \"#{opts.first[0]}\" because region presence check failed"
+        # Confirm that we are on the expected page
+        verify_presence "Cannot navigate to region \"#{region_name}\" because region presence check failed"
 
         # Apply the filter method
-        region.filter(opts.first[1])
+        if opts.is_a?(Hash)
+          region.filter(opts.first[1])
+        else
+          region.filter(opts)
+        end
 
         return region
       else

--- a/parfait.gemspec
+++ b/parfait.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'parfait'
-  s.version     = '0.12.3'
+  s.version     = '0.12.4'
   s.date        = '2017-08-25'
   s.summary     = 'Parfait'
   s.description = 'Parfait uses layers to simplify the creation and maintenance of your web browser test automation.'

--- a/test/test_region.rb
+++ b/test/test_region.rb
@@ -115,14 +115,26 @@ class RegionTest < Minitest::Test
 
   def test_filter_flexibility
     p = Parfait::Page.new(:name => "page")
-    r1 = Parfait::Region.new(:name => "region1")
-    r1.add_filter { |a| a }
-    assert r1.add_to_page(p).is_a?(Parfait::Region)
+    x = "cat"
+    r1 = Parfait::Region.new(:name => "region1", :parent => p)
+    r1.add_filter { |a| x = "dog" }
     assert p.region("region1") == r1
-    r2 = Parfait::Region.new(:name => "region2")
-    r2.add_filter { true }
-    assert r2.add_to_page(p).is_a?(Parfait::Region)
+    assert x == "dog"
+
+    r2 = Parfait::Region.new(:name => "region2", :parent => p)
+    r2.add_filter { x = "bird" }
     assert p.region("region2") == r2
+    assert x == "bird"
+
+    r3 = Parfait::Region.new(:name => "region3", :parent => r1)
+    r3.add_filter { |a| x = "cow" }
+    assert p.region("region1").region("region3") == r3
+    assert x == "cow"
+
+    r4 = Parfait::Region.new(:name => "region4", :parent => r1)
+    r4.add_filter { x = "pig" }
+    assert p.region("region1").region("region4") == r4
+    assert x == "pig"
   end
 
 end


### PR DESCRIPTION
Update in previous version allowed for regions within pages to utilize parameterless filters.  This update does the same for regions within regions.